### PR TITLE
fix: media queries for about page graphic

### DIFF
--- a/src/components/about/Hero.jsx
+++ b/src/components/about/Hero.jsx
@@ -16,7 +16,7 @@ export function Hero({ content }) {
         <HeroHeading>About Us</HeroHeading>
         <p>{content}</p>
 
-        <Button to={'/contact'}>Contact Us</Button>
+        <Button to={"/contact"}>Contact Us</Button>
       </HeroContent>
 
       <MobileGraphic>
@@ -99,6 +99,10 @@ const HeroContent = styled.div`
   @media (min-width: 1100px) {
     margin: 0;
     width: max(50vw, calc(100vw - 700px));
+    transform: translateX(-300px);
+  }
+  @media (min-width: 1400px) {
+    transform: none;
   }
 `
 


### PR DESCRIPTION
Added media queries for about page graphic 

large screen
![about-lg](https://github.com/heynovaio/heynovaio/assets/97143596/1113210b-4ebb-46ee-9d82-4647dffe8a1c)

mid screen
![about-mid](https://github.com/heynovaio/heynovaio/assets/97143596/c0bed920-c896-4749-8457-07570a92074a)
